### PR TITLE
fix: IDP-2171 gestione obbligatorieta trx expiration minutes e mapping initiative name

### DIFF
--- a/src/main/java/it/gov/pagopa/payment/dto/barcode/TransactionBarCodeResponse.java
+++ b/src/main/java/it/gov/pagopa/payment/dto/barcode/TransactionBarCodeResponse.java
@@ -17,7 +17,9 @@ public class TransactionBarCodeResponse {
     private String id;
     private String trxCode;
     private String initiativeId;
+    private String initiativeName;
     private OffsetDateTime trxDate;
     private SyncTrxStatus status;
     private Integer trxExpirationMinutes;
+    private Long residualBudgetCents;
 }

--- a/src/main/java/it/gov/pagopa/payment/dto/mapper/TransactionBarCodeInProgress2TransactionResponseMapper.java
+++ b/src/main/java/it/gov/pagopa/payment/dto/mapper/TransactionBarCodeInProgress2TransactionResponseMapper.java
@@ -26,9 +26,11 @@ public class TransactionBarCodeInProgress2TransactionResponseMapper
             .id(transactionInProgress.getId())
             .trxCode(transactionInProgress.getTrxCode())
             .initiativeId(transactionInProgress.getInitiativeId())
+            .initiativeName(transactionInProgress.getInitiativeName())
             .trxDate(transactionInProgress.getTrxDate())
             .trxExpirationMinutes(authorizationExpirationMinutes)
             .status(transactionInProgress.getStatus())
+            .residualBudgetCents(transactionInProgress.getAmountCents())
             .build();
   }
 }

--- a/src/test/java/it/gov/pagopa/payment/service/payment/barcode/BarCodeCreationServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/payment/service/payment/barcode/BarCodeCreationServiceImplTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -226,15 +227,16 @@ class BarCodeCreationServiceImplTest {
         Assertions.assertEquals(PaymentConstants.ExceptionCode.INITIATIVE_NOT_DISCOUNT, result.getCode());
     }
 
-    @Test
-    void createTransaction_UserBudgetExhausted() {
+    @ParameterizedTest
+    @ValueSource(longs = {-100, 0})
+    void createTransaction_UserBudgetExhausted(long budgetAmount) {
 
         TransactionBarCodeCreationRequest trxCreationReq = TransactionBarCodeCreationRequest.builder()
                 .initiativeId("INITIATIVEID")
                 .build();
 
         WalletDTO walletDTO = WalletDTOFaker.mockInstance(1, "REFUNDABLE");
-        walletDTO.setAmount(BigDecimal.ZERO);
+        walletDTO.setAmount(BigDecimal.valueOf(budgetAmount));
 
         when(rewardRuleRepository.findById("INITIATIVEID")).thenReturn(Optional.of(buildRule("INITIATIVEID", InitiativeRewardType.DISCOUNT)));
         when(walletConnector.getWallet("INITIATIVEID", "USERID")).thenReturn(walletDTO);


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The purpose of this pr is to add the fields initiativeName and residualBudgetCents to the response of the bar code creation api

#### List of Changes
<!--- Describe your changes in detail -->
- Added mapping of fields initiativeName and residualBudgetCents to Bar Code creation response

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [X] Unit
    - [ ] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.